### PR TITLE
Added support for DoctrineProvider wrapped cache adapters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "gspirov/zendframework1-doctrine2",
     "require": {
         "zendframework/zendframework1": "~1.9",
-        "doctrine/orm": "~2.3"
+        "doctrine/orm": "^2.3"
     },
     "autoload": {
         "psr-0": {"Bisna": "library/"}

--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -215,6 +215,13 @@ class Container
             'namespace'    => '',
             'options'      => array()
         );
+        if (class_exists('Doctrine\Common\Cache\Psr6\DoctrineProvider')) {
+            $defaultCacheInstance = array(
+                'adapterClass' => 'Symfony\Component\Cache\Adapter\ArrayAdapter',
+                'namespace'    => '',
+                'options'      => array()
+            );
+        }
 
         $instances = array();
 
@@ -617,6 +624,10 @@ class Container
             $adapter = new $adapterClass($directory, $extension);
         } else {
             $adapter = new $adapterClass();
+        }
+
+        if (class_exists('Doctrine\Common\Cache\Psr6\DoctrineProvider')) {
+            $adapter = \Doctrine\Common\Cache\Psr6\DoctrineProvider::wrap($adapter);
         }
         
         // Define namespace for cache


### PR DESCRIPTION
Added support for DoctrineProvider wrapped cache adapters, and raised the acceptable doctrine ORM versions to any in the 2 family after 2.3.